### PR TITLE
wall_follow

### DIFF
--- a/self_drive.cpp
+++ b/self_drive.cpp
@@ -1,0 +1,108 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+using namespace std::chrono_literals;
+
+class SelfDrive : public rclcpp::Node
+{
+  rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pose_pub_;
+  int step_;
+  bool wall_following_;  // Flag to indicate whether the turtle is wall following
+
+public:
+  SelfDrive() : rclcpp::Node("self_drive"), step_(0), wall_following_(false)
+  {
+    auto lidar_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    lidar_qos_profile.reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    auto callback = std::bind(&SelfDrive::subscribe_scan, this, std::placeholders::_1);
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile, callback);
+    auto vel_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
+    pose_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", vel_qos_profile);
+  }
+
+  void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
+  {
+    geometry_msgs::msg::Twist vel;
+
+    // Check if an obstacle is near (within 25cm)
+    if (is_obstacle_near(scan, 0.25))
+    {
+      // Obstacle detected nearby, rotate to avoid obstacle
+      vel.linear.x = 0.;
+      vel.angular.z = 0.5;  // Rotate to avoid the obstacle
+      wall_following_ = false;  // Stop wall following
+    }
+    else if (wall_following_)
+    {
+      // Wall following mode
+      vel.linear.x = std::max(0.15, 0.1);  // Maintain a minimum linear speed of 15cm/s
+      vel.angular.z = calculate_angular_velocity(scan, 35.0);  // Follow the wall
+    }
+    else
+    {
+      // Initial mode: Move forward until a wall is detected
+      vel.linear.x = 0.2;
+      vel.angular.z = 0.;
+      if (is_wall_in_front(scan, 0.5))
+      {
+        // Wall detected in front, switch to wall following mode
+        wall_following_ = true;
+      }
+    }
+
+    RCLCPP_INFO(rclcpp::get_logger("self_drive"),
+                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f, wall_following=%d",
+                step_, scan->ranges[0], vel.linear.x, vel.angular.z, static_cast<int>(wall_following_));
+
+    pose_pub_->publish(vel);
+    step_++;
+  }
+
+private:
+  bool is_obstacle_near(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
+  {
+    // Check if there is an obstacle nearby
+    for (auto range : scan->ranges)
+    {
+      if (range < threshold)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool is_wall_in_front(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
+  {
+    // Check if there is a wall in front of the turtle
+    return scan->ranges[0] < threshold;
+  }
+
+  double calculate_angular_velocity(const sensor_msgs::msg::LaserScan::SharedPtr scan, double target_distance)
+  {
+    double wall_distance = scan->ranges[0];  // Distance to the wall in front of the turtle
+    double error = wall_distance - target_distance;
+
+    // P-controller for wall following
+    double kp = 0.1;  // Proportional gain
+    double angular_velocity = kp * error;
+
+    return angular_velocity;
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<SelfDrive>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/self_drive.cpp
+++ b/self_drive.cpp
@@ -6,6 +6,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 using namespace std::chrono_literals;
 
@@ -14,15 +15,15 @@ class SelfDrive : public rclcpp::Node
   rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pose_pub_;
   int step_;
-  bool wall_following_;  // Flag to indicate whether the turtle is wall following
 
 public:
-  SelfDrive() : rclcpp::Node("self_drive"), step_(0), wall_following_(false)
+  SelfDrive() : rclcpp::Node("self_drive"), step_(0)
   {
     auto lidar_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
     lidar_qos_profile.reliability(rclcpp::ReliabilityPolicy::BestEffort);
     auto callback = std::bind(&SelfDrive::subscribe_scan, this, std::placeholders::_1);
-    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile, callback);
+    scan_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("/scan", lidar_qos_profile,
+                                                                       callback);
     auto vel_qos_profile = rclcpp::QoS(rclcpp::KeepLast(1));
     pose_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel", vel_qos_profile);
   }
@@ -30,71 +31,32 @@ public:
   void subscribe_scan(const sensor_msgs::msg::LaserScan::SharedPtr scan)
   {
     geometry_msgs::msg::Twist vel;
-
-    // Check if an obstacle is near (within 25cm)
-    if (is_obstacle_near(scan, 0.25))
+    if (scan->ranges[0] < 0.25 || scan->ranges[20] < 0.25)
     {
-      // Obstacle detected nearby, rotate to avoid obstacle
       vel.linear.x = 0.;
-      vel.angular.z = 0.5;  // Rotate to avoid the obstacle
-      wall_following_ = false;  // Stop wall following
+      vel.angular.z = -0.5;
     }
-    else if (wall_following_)
+    else if(scan->ranges[20] < 0.25 || scan->ranges[40] < 0.25)
     {
-      // Wall following mode
-      vel.linear.x = std::max(0.15, 0.1);  // Maintain a minimum linear speed of 15cm/s
-      vel.angular.z = calculate_angular_velocity(scan, 35.0);  // Follow the wall
+      vel.linear.x = 0.15;
+      vel.angular.z = -0.01;
+    }
+    else if(scan->ranges[40] < 0.25 || scan->ranges[60] < 0.25)
+    {
+       vel.linear.x = 0.15;
+      vel.angular.z = -0.01;
     }
     else
     {
-      // Initial mode: Move forward until a wall is detected
-      vel.linear.x = 0.2;
+      vel.linear.x = 0.15;
       vel.angular.z = 0.;
-      if (is_wall_in_front(scan, 0.5))
-      {
-        // Wall detected in front, switch to wall following mode
-        wall_following_ = true;
-      }
     }
-
+    
     RCLCPP_INFO(rclcpp::get_logger("self_drive"),
-                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f, wall_following=%d",
-                step_, scan->ranges[0], vel.linear.x, vel.angular.z, static_cast<int>(wall_following_));
-
+                "step=%d, range=%1.2f, linear=%1.2f, angular=%1.2f", step_, scan->ranges[0],
+                vel.linear.x, vel.angular.z);
     pose_pub_->publish(vel);
     step_++;
-  }
-
-private:
-  bool is_obstacle_near(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
-  {
-    // Check if there is an obstacle nearby
-    for (auto range : scan->ranges)
-    {
-      if (range < threshold)
-      {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool is_wall_in_front(const sensor_msgs::msg::LaserScan::SharedPtr scan, double threshold)
-  {
-    // Check if there is a wall in front of the turtle
-    return scan->ranges[0] < threshold;
-  }
-
-  double calculate_angular_velocity(const sensor_msgs::msg::LaserScan::SharedPtr scan, double target_distance)
-  {
-    double wall_distance = scan->ranges[0];  // Distance to the wall in front of the turtle
-    double error = wall_distance - target_distance;
-
-    // P-controller for wall following
-    double kp = 0.1;  // Proportional gain
-    double angular_velocity = kp * error;
-
-    return angular_velocity;
   }
 };
 


### PR DESCRIPTION
이 브랜치는 벽을 마주하게 되면 정지하고 벽을 따라가게 하기 위한 코드를 만들기 위해 제작되었습니다.
전방 25cm 이하의 거리에서 벽을 인식합니다.
벽이 있을 경우 정지하고 좌회전을 하고 wall_following을 false로 설정했습니다.
그 이외에는 wall_following 상태를 실행합니다.
wall following 상태에서는 0.15의 속도를 이용하여 직진을 하다 벽을 따라 좌회전합니다.
그 외에서는 다시 직진합니다.
이런식으로 계속 반복하여 직진 후 좌회전을 이용하여 벽을 따라갑니다.
이 코드에서는 벽을 따라갈 때 wall_following을 true/false 값으로 받아 실행하거나 취소합니다.
하지만 이 코드가 제대로 작동하지 않아 wall_following이 아닌 if문을 이용하여 합니다.
또한 인식 각도를 다양하게 받아 계속 벽을 인식할 수 있게 해야 합니다.